### PR TITLE
Use kind-of >=6.0.3 everywhere

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,5 +58,8 @@
     "url-loader": "^1.0.1",
     "uuid": "^3.3.2",
     "xxhashjs": "^0.2.2"
+  },
+  "resolutions": {
+    "kind-of": ">=6.0.3"
   }
 }


### PR DESCRIPTION
This repo's dependencies currently use [older versions](https://github.com/paritytech/substrate-ui/blob/b185aad6174ee6bf2f2a68eadd84801ec2efe39d/yarn.lock#L3362) of kind-of which have a possibly exploitable vulnerability ([original issue](https://github.com/jonschlinkert/kind-of/issues/30), [PR](https://github.com/jonschlinkert/kind-of/pull/31)).

Couldn't run `yarn install` to update the yarn.lock; could you do this?